### PR TITLE
Add in search repetition detection

### DIFF
--- a/core/include/engine.h
+++ b/core/include/engine.h
@@ -30,7 +30,6 @@ namespace chess
         Engine(EngineConfig config = EngineConfig())
             : m_quit(false), m_transTable(config.transpositionTableMBs)
         {
-            m_repTable.addState(m_currentBoard);
         }
 
         // The main way users will interface with the engine
@@ -74,11 +73,11 @@ namespace chess
             if (chosenMove.resets50MoveRule())
                 m_repTable.clear();
 
+            // Add the previous board to the repetition table for memory
+            // (current board is added at the root of the search)
+            m_repTable.addState(m_currentBoard);
+
             m_currentBoard.makeMove(chosenMove);
-
-            // Add the current board to the reperition table
-            bool success = m_repTable.addState(m_currentBoard);
-
             return true;
         }
 
@@ -101,8 +100,6 @@ namespace chess
 
             m_transTable.clear();
             m_repTable.clear();
-
-            m_repTable.addState(m_currentBoard);
         }
 
         enum class BenchType

--- a/core/include/repetitionTable.h
+++ b/core/include/repetitionTable.h
@@ -5,7 +5,6 @@
 
 namespace chess
 {
-
     struct RepetitionTable
     {
 
@@ -14,18 +13,13 @@ namespace chess
             m_length = 0;
         }
 
-        // Not performance critical, this is only called when a move is made on the root board
-        // via the engine makeMove method.
-        // returns wether the insert was succesfull (table not full)
         inline bool addState(const BoardState &b)
         {
             if (!m_length)
                 m_startsOnWhite = b.whitesMove();
 
-            if (m_length > 100)
-                return false;
-
             m_table[m_length] = b.repetitionHash();
+
             m_length++;
             return true;
         }
@@ -34,6 +28,9 @@ namespace chess
         {
             m_length = 0;
         }
+
+        // Pops the last entry in the repetition table
+        inline void pop() { m_length--; }
 
         inline bool drawBy50MoveRule() const
         {
@@ -48,6 +45,8 @@ namespace chess
         inline bool contains(const BoardState &b) const
         {
             bool checkEvenIdx = b.whitesMove() == m_startsOnWhite;
+            key boardHash = b.repetitionHash();
+
             int idx = m_length - 1;
 
             // Ensure we start on an even/odd idx
@@ -60,7 +59,7 @@ namespace chess
             {
                 // If the b.getHash contains enpassent data then we cannot have repetition anyways!
                 // (from the root we cannot do a double pawn move and have repetition at any point)
-                if (m_table[idx] == b.repetitionHash())
+                if (m_table[idx] == boardHash)
                     return true;
 
                 // Skip hashes where it isn't the same colors turn

--- a/core/include/search.h
+++ b/core/include/search.h
@@ -21,12 +21,12 @@ namespace chess
         struct SearchConfig
         {
             std::function<score(const BoardState &)> evalFunction;
-            const RepetitionTable *repTable = nullptr;
+            RepetitionTable *repTable = nullptr;
             TranspositionTable *transTable = nullptr;
 
             SearchConfig() = default;
 
-            SearchConfig(std::function<int(const BoardState &)> evalFunc, const RepetitionTable *const rt = nullptr)
+            SearchConfig(std::function<int(const BoardState &)> evalFunc, RepetitionTable *const rt = nullptr)
                 : evalFunction(evalFunc), repTable(rt)
             {
             }
@@ -147,7 +147,7 @@ namespace chess
     private:
         const std::function<score(const BoardState &)> m_evalFunc;
         // Repetition table passed down by the engine class
-        const RepetitionTable *m_repTable;
+        RepetitionTable *m_repTable;
         TranspositionTable *m_transTable;
         const BoardState m_rootBoard;
         // current best found move:

--- a/docs/engineImprovements.md
+++ b/docs/engineImprovements.md
@@ -111,13 +111,15 @@ Since we all but guarantee that the previous best move is searched first (except
 ## Principle Variation Search (PVS) (v0.7.3)
 
 We first refactored our search to the negamax approach instead of templating on bool Max. Which might have slightly boosted performance. To implement PVS we always search the first move (principle variation) fully and then only do a null window search on other moves to check if they need a full search. In some cases the bestEval in the search will be the result of a null window search. In these cases this only gives an upper bound even though the eval is between beta and alpha.
-Decent improvement: 
+Decent improvement: 142 wins, 70 draws and 110 losses.
 
+## In search repetition (v0.7.4)
+
+Previously we were only comparing against positions from the game and not against positions reached during the search to determine repetitions. We now also detect repetitions against positions in the search tree itself.
+Slight improvement: 417 wins, 195 draws and 388 losses.
 
 ## TODO:
 
-- move ordering
-- don't discard partial search
 - move extensions
 - multi threading
 

--- a/lichessBot.py
+++ b/lichessBot.py
@@ -98,10 +98,11 @@ def playGame(game_id):
             move = engine.go(0, ourTime, 0, 0)
         try:
             client.bots.make_move(game_id, move)
-        except:
+        except Exception as e:
             print(f"Error could not make move {move}")
             print("Engine position: ", engine.getPosition())
             engine.quit()
+            print(e)
             return
 
     for event in client.bots.stream_game_state(game_id):
@@ -138,12 +139,17 @@ def playGame(game_id):
                 binc = event['binc'].timestamp()
                 print(f"Time w: {wtime} b: {btime}, inc: {(winc, binc)}")
                 engineMove = engine.go(wtime, btime, winc, binc)
+                print("Engine position: ", engine.getPosition())
                 
                 try:
                     client.bots.make_move(game_id, engineMove)
-                except:
+                except Exception as e:
                     print(f"Error could not make move {engineMove}")
                     print("Engine position: ", engine.getPosition())
+                    engine.quit()
+                    print(e)
+                    # Retry
+                    playGame(game_id)
                     break
                 
             case "chatLine":

--- a/testing/data/engineComparison.json
+++ b/testing/data/engineComparison.json
@@ -47,5 +47,12 @@
         "engine1Wins": 123,
         "draws": 104,
         "engine2Wins": 773
+    },
+    {
+        "engine1": "../releases/engine-v0.7.3",
+        "engine2": "../build/app/engine",
+        "engine1Wins": 388,
+        "draws": 195,
+        "engine2Wins": 417
     }
 ]

--- a/testing/enginePlayout.py
+++ b/testing/enginePlayout.py
@@ -159,9 +159,8 @@ if __name__ == "__main__":
 
     print(f"Using fens file {fensFile}")
 
-    e1 = ChessEngine("../releases/engine-v0.7.2")
+    e1 = ChessEngine("../releases/engine-v0.7.3")
     e2 = ChessEngine("../build/app/engine")
-    # e2 = ChessEngine("../build/app/engine")
 
     result = compareEngines(e1, e2, fensFile=fensFile)
     storeComparison(e1, e2, result)


### PR DESCRIPTION
Also detects repetition against boards earlier in the current search.
This allows for the engine to see forced repetitions and either avoid or steer towards them.